### PR TITLE
Fix up cmake file. Format readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ParallelFlowDir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,11 @@
 #the minimum version
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.9)
 
 project (ParallelFlowDir LANGUAGES CXX)
 message("Project Name:" ${PROJECT_NAME})
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-add_compile_options(-std=c++11 -fpermissive -O3)
+find_package(MPI REQUIRED)
+find_package(GDAL REQUIRED)
 
 #The output directory of the execution file
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
@@ -19,25 +16,37 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 #header file 2
 include_directories(${PROJECT_SOURCE_DIR}/src/flowdir})
 
-#Add the cereal libraty path
-include_directories(/share/home/cereal/include)
-
-aux_source_directory(${PROJECT_SOURCE_DIR}/src/common c_files)
-aux_source_directory(${PROJECT_SOURCE_DIR}/src/flowdir c_files)
-
-find_package(MPI REQUIRED)
-set(CMAKE_MPI MPI::MPI_CXX)
-
-
 #If find_package(GDAL REQUIRED) cannot find GDAL, you can set the GDAL_LIBRARY by yourself
 #set(GDAL_INCLUDE_DIR /share/home/user/gdalBuild/include)
 #set(GDAL_LIBRARY /share/home/user/gdalBuild/lib/libgdal.so)
 
-find_package(GDAL REQUIRED)
 message(STATUS " version:${GDAL_VERSION}")
 message(STATUS " libraries:${GDAL_LIBRARY}")
 message(STATUS " include path:${GDAL_INCLUDE_DIR}")
 
-add_executable(${PROJECT_NAME} ${c_files})
+add_executable(${PROJECT_NAME}
+  src/flowdir/producer_2_consumer.cpp
+  src/flowdir/producer.cpp
+  src/flowdir/outBoundary.cpp
+  src/flowdir/object_factory.cpp
+  src/flowdir/main.cpp
+  src/flowdir/host.cpp
+  src/flowdir/consumer_2_producer.cpp
+  src/flowdir/consumer.cpp
+  src/flowdir/GridCell.cpp
+  src/common/tool.cpp
+  src/common/timeInfo.cpp
+  src/common/tile_info.cpp
+  src/common/raster.cpp
+  src/common/object_deleter.cpp
+  src/common/memory.cpp
+  src/common/grid.cpp
+  src/common/gdal.cpp
+  src/common/bit_raster.cpp
+  src/common/Timer.cpp
+)
 
-target_link_libraries(${PROJECT_NAME} ${GDAL_LIBRARY} ${CMAKE_MPI})
+target_link_libraries(${PROJECT_NAME} ${GDAL_LIBRARY} MPI::MPI_CXX)
+target_include_directories(${PROJECT_NAME} PRIVATE ${GDAL_INCLUDE_DIR})
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+target_compile_options(${PROJECT_NAME} PRIVATE -fpermissive -Wall -pedantic)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ParallelFlowDirections
 
-**Manuscript Title**: Parallel assignment of flow directions over flat surfaces in massive digital elevation models  
+**Manuscript Title**: Parallel assignment of flow directions over flat surfaces in massive digital elevation models
 
-**Authors**: Lihui Song, Guiyun Zhou, Yi Liu  
+**Authors**: Lihui Song, Guiyun Zhou, Yi Liu
 
-**Corresponding Author**: Guiyun Zhou(zhouguiyun@uestc.edu.cn)  
+**Corresponding Author**: Guiyun Zhou (zhouguiyun@uestc.edu.cn)
 
 
 # Abstract
@@ -12,64 +12,67 @@ The assignment of flow directions in flat regions needs to be treated with speci
 
 # Prerequisite
 
-GDAL , MPI and cereal
+GDAL, MPI, and cereal
 
 # Compilation
 
 To compile the programs run:
 ```
-cmake .
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 make
 ```
-The result is a program called  `ParallelFlowDir`.
+The result is a program called `ParallelFlowDir`.
 
 # Program argumens
 
 The program can be run using MPI with two modes: `parallel` and `test`. In `parallel` mode, the program derives flow directions. In `test` mode, the program run test cases on randomly generated DEMs.
 
-In `parallel` mode, the program has the following arguments: 
+In `parallel` mode, the program has the following arguments:
 ```
 mpirun -np <PROCESSES_NUMBER> ParallelFlowDir parallel <INPUT> <OUTPUT>
 ```
-The `<INPUT>` argument is a text file and contains the paths of the tiles of the DEM.  
-The `<OUTPUT>` argument specifes the output folder.   
+The `<INPUT>` argument is a text file and contains the paths of the tiles of the DEM.
+The `<OUTPUT>` argument specifes the output folder.
 
-An example command is: `mpirun -np 3 ParallelFlowDir parallel ./test_data/ansai_part.txt ./test_data/ansai_flow`   
-`-np 3` indicates that the program is run in parallel over 3 processes, which includes 1 producer process and 2 consumer processes.  
+An example command is: `mpirun -np 3 ParallelFlowDir parallel ./test_data/ansai_part.txt ./test_data/ansai_flow`
+`-np 3` indicates that the program is run in parallel over 3 processes, which includes 1 producer process and 2 consumer processes.
 
-In `test` mode, the program has the following arguments: 
+In `test` mode, the program has the following arguments:
+```bash
+mpirun -np <PROCESSES_NUMBER> ParallelFlowDir test <OUTPUT_PATH_OF_DEM> <HEIGHT_OF_THE_DEM > <WIDTH_OF_THE_DEM> <OUTPUT_PATH_OF_SEQUENTIAL_FLOW_DIRECTIONS> <TILE_HEIGHT> <TILE_WIDTH> <DIVIDE_FOLDER> <OUTPUT_FOLDER_OF_PARALLEL_FLOW_DIRECIOTNS>
 ```
-mpirun -np <PROCESSES_NUMBER> ParallelFlowDir test <OUTPUT_PATH_OF_DEM> <HEIGHT_OF_THE_DEM > <WIDTH_OF_THE_DEM> <OUTPUT_PATH_OF_SEQUENTIAL_FLOW_DIRECTIONS> <TILE_HEIGHT> <TILE_WIDTH> <DIVIDE_FOLDER> <OUTPUT_FOLDER_OF_PARALLEL_FLOW_DIRECIOTNS>   
+The `<OUTPUT_PATH_OF_DEM>` argument specifes the output path of the randomly generated DEM.
+The `<HEIGHT_OF_THE_DEM>` argument specifes the height of the DEM.
+The `<WIDTH_OF_THE DEM>` argument specifes the width of the DEM.
+The `<OUTPUT_PATH_OF_SEQUENTIAL_FLOW_DIRECTIONS>` argument specifes the output path of the flow directions using the sequential Barnes algorithm.
+The `<TILE HEIGHT>` argument specifes the height of the tile.
+The `<TILE_WIDTH>` argument specifes the width of the tile.
+The `<DIVIDE_PATH>` argument specifes the output folder of the tiles.
+The `<OUTPUT_FOLDER_OF_PARALLEL_FLOW_DIRECTIONS>` argument specifes the output folder of flow directions using our proposed parallel algorithm.
+
+An example command is:
+```bash
+mpirun -np 4 ParallelFlowDir test ./test_data/dem.tif 2000 3000 ./test_data/seqFlow/seqFlow.tif 500 800 ./test_data/tileDEM ./test_data/paraFlow
 ```
-The `<OUTPUT_PATH_OF_DEM>` argument specifes the output path of the randomly generated DEM.  
-The `<HEIGHT_OF_THE_DEM>` argument specifes the height of the DEM.   
-The `<WIDTH_OF_THE DEM>` argument specifes the width of the DEM.   
-The `<OUTPUT_PATH_OF_SEQUENTIAL_FLOW_DIRECTIONS>` argument specifes the output path of the flow directions using the sequential Barnes algorithm.  
-The `<TILE HEIGHT>` argument specifes the height of the tile.   
-The `<TILE_WIDTH>` argument specifes the width of the tile.   
-The `<DIVIDE_PATH>` argument specifes the output folder of the tiles.  
-The `<OUTPUT_FOLDER_OF_PARALLEL_FLOW_DIRECTIONS>` argument specifes the output folder of flow directions using our proposed parallel algorithm.  
+`-np 4` indicates that the program is run in parallel over 4 processes, which includes 1 producer process and 3 consumer processes.
 
-An example command is: `mpirun -np 4 ParallelFlowDir test ./test_data/dem.tif 2000 3000 ./test_data/seqFlow/seqFlow.tif 500 800 ./test_data/tileDEM ./test_data/paraFlow `   
-`-np 4` indicates that the program is run in parallel over 4 processes, which includes 1 producer process and 3 consumer processes. 
+# Format of input file
 
-# Format of input file 
-
-The input file includes a two dimensional array of file paths of tiles.  
+The input file includes a two dimensional array of file paths of tiles.
 ```
 f1.tif, f2.tif, f3.tif, f4.tif,
       , f5.tif, f6.tif, f7.tif,
       , f8.tif, f9.tif,
 ```
-If the file path is blank, it indicate that there is no tile there. The file format can be any type that GDAL support. 
+If the file path is blank, it indicate that there is no tile there. The file format can be any type that GDAL support.
 
 # Testing
 
-The program has a `test` mode, which verifies the correctness of our proposed parallel algorithm by comparing with the output of sequential algorithm using randomly generated DEMs.   
+The program has a `test` mode, which verifies the correctness of our proposed parallel algorithm by comparing with the output of sequential algorithm using randomly generated DEMs.
 If using the sequential Barnes algorithm and our parallel algorithm results in the same flow directions, the program will output `The two Rasters are the same!`.
 
 # Test data
 
 The test_data folder contains two test datasets that can be used with the program.
-
-


### PR DESCRIPTION
This PR modernizes the cmake by using target-specific options. It also adds some light formatting to the readme.

A prominent change is enabling compilation warnings via `-Wall -pedantic`.